### PR TITLE
feat: strengthen cooldown and budget policy controls

### DIFF
--- a/src/main/java/com/geo/sdk/core/CoreSdk.java
+++ b/src/main/java/com/geo/sdk/core/CoreSdk.java
@@ -367,25 +367,65 @@ public final class CoreSdk {
     }
 
     public static final class BudgetPolicyEngine implements Policy {
-        private final double askThreshold;
+        public record PolicyConfig(
+                double askThreshold,
+                boolean allowContextForceSilent,
+                boolean allowContextForceSkip) {
+        }
+
+        private final PolicyConfig config;
 
         public BudgetPolicyEngine(double askThreshold) {
-            this.askThreshold = askThreshold;
+            this(new PolicyConfig(askThreshold, true, true));
+        }
+
+        public BudgetPolicyEngine(PolicyConfig config) {
+            this.config = Objects.requireNonNull(config);
+            if (Double.isNaN(config.askThreshold()) || Double.isInfinite(config.askThreshold())) {
+                throw new IllegalArgumentException("askThreshold must be finite");
+            }
         }
 
         @Override
         public ActionPlan decide(ScoreResult score, Budget budget, Context ctx) {
-            if (score.value() < askThreshold) {
+            Objects.requireNonNull(score, "score must not be null");
+            Objects.requireNonNull(budget, "budget must not be null");
+            Objects.requireNonNull(ctx, "ctx must not be null");
+
+            Map<String, String> tags = ctx.tags() == null ? Map.of() : ctx.tags();
+            if (config.allowContextForceSilent() && isTrue(tags.get("policy_force_silent"))) {
+                return new ActionPlan(ActionType.SILENT, "forced-silent", ctx.nowEpochMs());
+            }
+            if (config.allowContextForceSkip() && isTrue(tags.get("policy_force_skip"))) {
+                return new ActionPlan(ActionType.SKIP, "forced-skip", ctx.nowEpochMs());
+            }
+
+            if (budget.dailyAskLimit() < 0 || budget.asksUsedToday() < 0 || budget.questionBudget() < 0 || budget.cooldownMs() < 0) {
+                return new ActionPlan(ActionType.SKIP, "invalid-budget", ctx.nowEpochMs());
+            }
+
+            if (Double.isNaN(score.value()) || Double.isInfinite(score.value())) {
+                return new ActionPlan(ActionType.SKIP, "invalid-score", ctx.nowEpochMs());
+            }
+
+            if (score.value() < config.askThreshold()) {
                 return new ActionPlan(ActionType.SILENT, "below-threshold", ctx.nowEpochMs());
             }
-            if (budget.questionBudget() <= 0 || budget.asksUsedToday() >= budget.dailyAskLimit()) {
-                return new ActionPlan(ActionType.SKIP, "budget-exhausted", ctx.nowEpochMs());
+            if (budget.asksUsedToday() >= budget.dailyAskLimit()) {
+                return new ActionPlan(ActionType.SKIP, "daily-limit-exhausted", ctx.nowEpochMs());
+            }
+            if (budget.questionBudget() <= 0) {
+                return new ActionPlan(ActionType.SKIP, "question-budget-exhausted", ctx.nowEpochMs());
             }
             long cooldownUntil = budget.lastAskEpochMs() + budget.cooldownMs();
             if (ctx.nowEpochMs() < cooldownUntil) {
                 return new ActionPlan(ActionType.SKIP, "cooldown-active", cooldownUntil);
             }
             return new ActionPlan(ActionType.ASK, "eligible", ctx.nowEpochMs() + budget.cooldownMs());
+        }
+
+        private static boolean isTrue(String value) {
+            return "true".equalsIgnoreCase(value);
         }
     }
 

--- a/src/test/java/com/geo/sdk/core/SdkTestMain.java
+++ b/src/test/java/com/geo/sdk/core/SdkTestMain.java
@@ -29,6 +29,7 @@ public final class SdkTestMain {
         testPipelineSkipsWhenNoScorableCandidate();
         testPipelineContinuesAfterCandidateFailure();
         testPolicyBoundaries();
+        testPolicyForceAndValidationControls();
         testUpdaterUndoAndDeterminism();
         testCompatibilityLoad();
     }
@@ -154,9 +155,13 @@ public final class SdkTestMain {
         ActionPlan below = policy.decide(new ScoreResult(0.1, "1", "t1"), new Budget(2, 0, 2, 1000L, 0L), ctx);
         assertEquals(ActionType.SILENT, below.type(), "below threshold should be silent");
 
-        ActionPlan budgetExhausted = policy.decide(new ScoreResult(0.9, "1", "t2"), new Budget(1, 1, 0, 1000L, 0L), ctx);
-        assertEquals(ActionType.SKIP, budgetExhausted.type(), "budget exhausted should skip");
-        assertEquals("budget-exhausted", budgetExhausted.reason(), "budget exhausted reason");
+        ActionPlan dailyExhausted = policy.decide(new ScoreResult(0.9, "1", "t2"), new Budget(1, 1, 2, 1000L, 0L), ctx);
+        assertEquals(ActionType.SKIP, dailyExhausted.type(), "daily cap exhausted should skip");
+        assertEquals("daily-limit-exhausted", dailyExhausted.reason(), "daily cap reason");
+
+        ActionPlan questionBudgetExhausted = policy.decide(new ScoreResult(0.9, "1", "t2b"), new Budget(3, 1, 0, 1000L, 0L), ctx);
+        assertEquals(ActionType.SKIP, questionBudgetExhausted.type(), "question budget exhausted should skip");
+        assertEquals("question-budget-exhausted", questionBudgetExhausted.reason(), "question budget reason");
 
         ActionPlan cooldown = policy.decide(new ScoreResult(0.9, "1", "t3"), new Budget(3, 0, 3, 10_000L, 3_000L), ctx);
         assertEquals(ActionType.SKIP, cooldown.type(), "cooldown should skip ask");
@@ -164,6 +169,29 @@ public final class SdkTestMain {
 
         ActionPlan ask = policy.decide(new ScoreResult(0.9, "1", "t4"), new Budget(3, 0, 3, 1000L, 1_000L), ctx);
         assertEquals(ActionType.ASK, ask.type(), "eligible score should ask");
+    }
+
+    private static void testPolicyForceAndValidationControls() {
+        Policy policy = new BudgetPolicyEngine(0.2);
+
+        Context forcedSilentCtx = new Context(5_000L, "Asia/Tokyo", Map.of("policy_force_silent", "true"));
+        ActionPlan forcedSilent = policy.decide(new ScoreResult(1.0, "1", "f1"), new Budget(3, 0, 3, 1000L, 0L), forcedSilentCtx);
+        assertEquals(ActionType.SILENT, forcedSilent.type(), "force-silent tag should override ask");
+        assertEquals("forced-silent", forcedSilent.reason(), "force-silent reason");
+
+        Context forcedSkipCtx = new Context(5_000L, "Asia/Tokyo", Map.of("policy_force_skip", "true"));
+        ActionPlan forcedSkip = policy.decide(new ScoreResult(1.0, "1", "f2"), new Budget(3, 0, 3, 1000L, 0L), forcedSkipCtx);
+        assertEquals(ActionType.SKIP, forcedSkip.type(), "force-skip tag should override ask");
+        assertEquals("forced-skip", forcedSkip.reason(), "force-skip reason");
+
+        Context normalCtx = new Context(5_000L, "Asia/Tokyo", Map.of());
+        ActionPlan invalidBudget = policy.decide(new ScoreResult(1.0, "1", "f3"), new Budget(-1, 0, 3, 1000L, 0L), normalCtx);
+        assertEquals(ActionType.SKIP, invalidBudget.type(), "invalid budget should skip");
+        assertEquals("invalid-budget", invalidBudget.reason(), "invalid budget reason");
+
+        ActionPlan invalidScore = policy.decide(new ScoreResult(Double.NaN, "1", "f4"), new Budget(3, 0, 3, 1000L, 0L), normalCtx);
+        assertEquals(ActionType.SKIP, invalidScore.type(), "invalid score should skip");
+        assertEquals("invalid-score", invalidScore.reason(), "invalid score reason");
     }
 
     private static void testUpdaterUndoAndDeterminism() {


### PR DESCRIPTION
## Summary
- Upgraded `BudgetPolicyEngine` with explicit control-path reasons for:
  - daily limit exhaustion
  - question budget exhaustion
  - cooldown active
  - invalid budget and invalid score
- Added optional context force controls (`policy_force_silent`, `policy_force_skip`) for wrapper-level intervention.
- Added `PolicyConfig` to configure threshold and force-control behavior.
- Expanded unit tests to cover all policy boundary branches.

## Linked Issue
- Closes #5
- Related #8

## Acceptance Criteria
- [x] Cooldown, daily cap, and question budget are independently enforced.
- [x] Decision reasons are explicit and test-covered.
- [x] Invalid input states fail safe (skip).

## Test Evidence
- `ci/run-lint.sh`
- `ci/run-unit.sh`
- `ci/run-contract.sh`
- `ci/run-security-audit.sh`

## Rollback Plan
- Revert this PR to restore previous policy behavior.

## Security & Privacy Impact
- [x] No external transfer paths added
- [x] No sensitive logging added
- [x] No secrets added
