### PR TITLE
feat: strengthen updater apply/undo with reproducibility checkpoints

### DIFF
--- a/src/main/java/com/geo/sdk/core/CoreSdk.java
+++ b/src/main/java/com/geo/sdk/core/CoreSdk.java
@@ -70,6 +70,7 @@ public final class CoreSdk {
     }
 
     public record FeedbackEvent(
+            String feedbackId,
             String candidateId,
             boolean positive,
             long timestampEpochMs) {
@@ -437,15 +438,50 @@ public final class CoreSdk {
     }
 
     public static final class InMemoryUpdater implements Updater {
+        public record UpdateCheckpoint(
+                String checkpointId,
+                String feedbackId,
+                String traceId,
+                long revisionBefore,
+                long revisionAfter,
+                String checksumBefore,
+                String checksumAfter) {
+        }
+
         private final double learningRate;
+        private final int maxHistory;
         private final Deque<ModelState> history = new ArrayDeque<>();
+        private final Deque<UpdateCheckpoint> checkpoints = new ArrayDeque<>();
+        private final Map<String, String> appliedFeedback = new HashMap<>();
 
         public InMemoryUpdater(double learningRate) {
+            this(learningRate, 128);
+        }
+
+        public InMemoryUpdater(double learningRate, int maxHistory) {
             this.learningRate = learningRate;
+            if (maxHistory <= 0) {
+                throw new IllegalArgumentException("maxHistory must be > 0");
+            }
+            this.maxHistory = maxHistory;
         }
 
         @Override
         public ModelState apply(FeedbackEvent feedback, ExecutionTrace trace, ModelState model) {
+            Objects.requireNonNull(feedback, "feedback must not be null");
+            Objects.requireNonNull(trace, "trace must not be null");
+            Objects.requireNonNull(model, "model must not be null");
+
+            if (feedback.feedbackId() == null || feedback.feedbackId().isBlank()) {
+                throw new IllegalArgumentException("feedback.feedbackId must not be blank");
+            }
+
+            // Idempotency: repeated apply for same feedbackId does nothing.
+            String traceChecksum = checkpointChecksum(model, trace);
+            if (appliedFeedback.containsKey(feedback.feedbackId())) {
+                return model;
+            }
+
             history.push(model);
             if (trace.selectedFeatureVector() == null) {
                 return model;
@@ -457,7 +493,20 @@ public final class CoreSdk {
                 double updated = oldWeight + (direction * feature.getValue() * learningRate);
                 nextWeights.put(feature.getKey(), updated);
             }
-            return new ModelState(model.modelVersion(), model.featureSchemaVersion(), nextWeights, model.revision() + 1);
+            ModelState updated = new ModelState(model.modelVersion(), model.featureSchemaVersion(), nextWeights, model.revision() + 1);
+
+            UpdateCheckpoint checkpoint = new UpdateCheckpoint(
+                    UUID.randomUUID().toString(),
+                    feedback.feedbackId(),
+                    trace.traceId(),
+                    model.revision(),
+                    updated.revision(),
+                    checkpointChecksum(model, trace),
+                    checkpointChecksum(updated, trace));
+            checkpoints.push(checkpoint);
+            appliedFeedback.put(feedback.feedbackId(), traceChecksum);
+            trimToMaxHistory();
+            return updated;
         }
 
         @Override
@@ -465,7 +514,39 @@ public final class CoreSdk {
             if (history.isEmpty()) {
                 throw new IllegalStateException("no-history");
             }
-            return history.pop();
+            ModelState previous = history.pop();
+            if (!checkpoints.isEmpty()) {
+                UpdateCheckpoint checkpoint = checkpoints.pop();
+                appliedFeedback.remove(checkpoint.feedbackId());
+            }
+            return previous;
+        }
+
+        public List<UpdateCheckpoint> checkpoints() {
+            return List.copyOf(checkpoints);
+        }
+
+        private void trimToMaxHistory() {
+            while (history.size() > maxHistory) {
+                history.removeLast();
+            }
+            while (checkpoints.size() > maxHistory) {
+                UpdateCheckpoint dropped = checkpoints.removeLast();
+                appliedFeedback.remove(dropped.feedbackId());
+            }
+        }
+
+        private static String checkpointChecksum(ModelState state, ExecutionTrace trace) {
+            int hash = Objects.hash(
+                    state.modelVersion(),
+                    state.featureSchemaVersion(),
+                    state.revision(),
+                    state.weights(),
+                    trace.traceId(),
+                    trace.selectedCandidate() == null ? "none" : trace.selectedCandidate().candidateId(),
+                    trace.selectedScore() == null ? 0.0 : trace.selectedScore().value(),
+                    trace.actionPlan() == null ? "none" : trace.actionPlan().reason());
+            return Integer.toHexString(hash);
         }
     }
 

--- a/src/test/java/com/geo/sdk/core/SdkTestMain.java
+++ b/src/test/java/com/geo/sdk/core/SdkTestMain.java
@@ -31,6 +31,7 @@ public final class SdkTestMain {
         testPolicyBoundaries();
         testPolicyForceAndValidationControls();
         testUpdaterUndoAndDeterminism();
+        testUpdaterIdempotencyAndCheckpointing();
         testCompatibilityLoad();
     }
 
@@ -204,7 +205,7 @@ public final class SdkTestMain {
         Budget budget = new Budget(10, 0, 5, 1000L, 0L);
 
         PipelineOutcome first = engine.run(input, ctx, budget, base);
-        ModelState updated = updater.apply(new FeedbackEvent(first.trace().selectedCandidate().candidateId(), true, 9_000L), first.trace(), base);
+        ModelState updated = updater.apply(new FeedbackEvent("fb-1", first.trace().selectedCandidate().candidateId(), true, 9_000L), first.trace(), base);
 
         ModelState rolledBack = updater.undo();
         assertEquals(base.weights(), rolledBack.weights(), "undo should restore exact previous weights");
@@ -215,6 +216,30 @@ public final class SdkTestMain {
 
         boolean changedAnyWeight = !updated.weights().equals(base.weights());
         assertTrue(changedAnyWeight, "positive feedback should update weights");
+    }
+
+    private static void testUpdaterIdempotencyAndCheckpointing() {
+        PipelineEngine engine = CoreSdk.defaultEngine();
+        ModelState base = CoreSdk.defaultModel();
+        InMemoryUpdater updater = new InMemoryUpdater(0.01, 4);
+
+        InputEvent input = new InputEvent("evt-up2", 35.0, 139.0, 1000L, Map.of("dwell_minutes", "7"));
+        Context ctx = new Context(8_000L, "Asia/Tokyo", Map.of());
+        Budget budget = new Budget(10, 0, 5, 1000L, 0L);
+        PipelineOutcome outcome = engine.run(input, ctx, budget, base);
+
+        FeedbackEvent feedback = new FeedbackEvent("fb-idem", outcome.trace().selectedCandidate().candidateId(), true, 9_000L);
+        ModelState once = updater.apply(feedback, outcome.trace(), base);
+        ModelState twice = updater.apply(feedback, outcome.trace(), once);
+
+        assertEquals(once.weights(), twice.weights(), "duplicate feedback id should not be applied twice");
+        assertEquals(once.revision(), twice.revision(), "duplicate feedback id should not advance revision");
+
+        assertEquals(1, updater.checkpoints().size(), "exactly one checkpoint should be stored");
+        InMemoryUpdater.UpdateCheckpoint checkpoint = updater.checkpoints().get(0);
+        assertEquals("fb-idem", checkpoint.feedbackId(), "checkpoint should capture feedback id");
+        assertEquals(base.revision(), checkpoint.revisionBefore(), "checkpoint revision before");
+        assertEquals(once.revision(), checkpoint.revisionAfter(), "checkpoint revision after");
     }
 
     private static void testCompatibilityLoad() {


### PR DESCRIPTION
## Summary
- Extended `FeedbackEvent` to include stable `feedbackId` for idempotent updates.
- Upgraded `InMemoryUpdater` with:
  - idempotency guard on `feedbackId`
  - bounded update history
  - update checkpoints (before/after revision + checksums)
  - safer undo that rolls back both model history and checkpoint metadata
- Added tests for duplicate feedback suppression and checkpoint integrity.

## Linked Issue
- Closes #6
- Related #8

## Acceptance Criteria
- [x] `apply` + `undo` path is robust and test-covered.
- [x] Repeated same feedback event does not double-apply updates.
- [x] Reproducibility checkpoints are captured per update.

## Test Evidence
- `ci/run-lint.sh`
- `ci/run-unit.sh`
- `ci/run-contract.sh`
- `ci/run-security-audit.sh`

## Rollback Plan
- Revert this PR to restore prior updater semantics.

## Security & Privacy Impact
- [x] No external transfer paths added
- [x] No sensitive logging added
- [x] No secrets added
