### PR TITLE
security: enforce stronger no-transfer and log-minimization audit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ policy:
 	ci/run-policy.sh
 
 security:
-	@if [ -x .github/workflows/ci.yml ]; then echo "security gate is on GitHub Actions"; fi
 	@echo "Run local secret scan"
 	@git grep -nE '(AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36}|AIza[0-9A-Za-z_-]{35}|-----BEGIN (RSA|OPENSSH|EC) PRIVATE KEY-----)' -- . ':!docs/*' && exit 1 || true
+	@ci/run-security-audit.sh
 	@echo "security: ok"

--- a/ci/run-security-audit.sh
+++ b/ci/run-security-audit.sh
@@ -1,19 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# M0 privacy gate:
-# - disallow direct network client imports in core runtime
-# - disallow obvious raw location logging patterns
+TARGET_DIR="src/main/java"
 
-if rg -n "import java\\.net\\.|HttpClient|OkHttp|Retrofit|URLConnection" src/main/java; then
-  echo "Security audit failed: network client usage found in core runtime."
+if [ ! -d "$TARGET_DIR" ]; then
+  echo "security-audit: no runtime source directory, skip"
+  exit 0
+fi
+
+# 1) No external transfer primitives in core runtime.
+NETWORK_PATTERN='import java\\.net\\.|java\\.net\\.(URL|URI|Socket|DatagramSocket|HttpURLConnection)|java\\.nio\\.channels\\.(SocketChannel|AsynchronousSocketChannel)|HttpClient|URLConnection|OkHttp|okhttp3|Retrofit|retrofit2|WebSocket|grpc|mqtt|ApacheHttpClient'
+if rg -n "$NETWORK_PATTERN" "$TARGET_DIR"; then
+  echo "Security audit failed: network transfer primitives found in runtime core."
   exit 1
 fi
 
-if rg -n "System\\.out\\.print|logger\\.|log\\(" src/main/java | rg -n "lat|lon|latitude|longitude|location"; then
-  echo "Security audit failed: possible raw location log output found."
+# 2) No endpoint literal in runtime core (prevents hidden exfil paths).
+if rg -n "https?://" "$TARGET_DIR"; then
+  echo "Security audit failed: endpoint literal found in runtime core."
+  exit 1
+fi
+
+# 3) Log minimization: disallow likely raw location/context payload logging.
+LOG_CALL_PATTERN='System\.out\.print(?:ln)?|logger\.|printStackTrace\(|\blog\s*\('
+SENSITIVE_PATTERN='lat|lon|latitude|longitude|location|InputEvent|Context|Candidate|FeatureVector|ScoreResult'
+if rg -n -P "$LOG_CALL_PATTERN" "$TARGET_DIR" | rg -n "$SENSITIVE_PATTERN"; then
+  echo "Security audit failed: possible sensitive runtime payload logging found."
   exit 1
 fi
 
 echo "security-audit: ok"
-

--- a/docs/agents/security-audit-controls.md
+++ b/docs/agents/security-audit-controls.md
@@ -1,0 +1,20 @@
+# Security Audit Controls
+
+`agent:security-audit` が CI とローカルで検証する最小コントロール。
+
+## Runtime Controls
+- Core runtime (`src/main/java`) にネットワーク転送プリミティブを置かない。
+- Core runtime に `http://` / `https://` の endpoint literal を置かない。
+- 生の位置/文脈/候補/スコア情報をログ出力しない。
+
+## CI Gate
+- `security` job で以下を実行:
+  - secret-like pattern scan
+  - dependency audit (best effort)
+  - `ci/run-security-audit.sh`
+
+## Exception Rule
+- 例外が必要な場合は以下を必須化:
+  - Security issue を事前起票
+  - 例外理由、データフロー、代替案、期限付き撤去計画を記録
+  - PM + Security Audit の両方で受け入れ判断


### PR DESCRIPTION
## Summary
- Hardened runtime security audit checks for core SDK source:
  - broader network primitive detection
  - endpoint literal (`http/https`) prohibition
  - sensitive payload logging detection
- Aligned local `make security` with CI by invoking `ci/run-security-audit.sh`.
- Added explicit security control document for audit policy and exceptions.

## Linked Issue
- Closes #9

## Acceptance Criteria
- [x] No-external-transfer checks are enforced in CI/local security gate.
- [x] Log minimization checks cover runtime-sensitive payload patterns.
- [x] Security control and exception policy is documented.

## Test Evidence
- `ci/run-security-audit.sh`
- `make security`
- `ci/run-lint.sh`
- `ci/run-unit.sh`
- `ci/run-contract.sh`
- `ci/run-consistency.sh`
- `ci/run-compatibility.sh`
- `ci/run-policy.sh`

## Rollback Plan
- Revert this PR to restore previous security-audit behavior.

## Security & Privacy Impact
- [x] No external transfer paths added
- [x] No sensitive logging added
- [x] Security gate strictness increased
