### PR TITLE
fix: harden update integrity and publish security review findings

### DIFF
--- a/docs/agents/security-review-2026-03-05.md
+++ b/docs/agents/security-review-2026-03-05.md
@@ -1,0 +1,36 @@
+# Security Review Report (2026-03-05)
+
+## Scope
+- Runtime core source (`src/main/java/com/geo/sdk/core`)
+- CI security gate (`ci/run-security-audit.sh`, `.github/workflows/ci.yml`)
+- Update integrity path (`InMemoryUpdater`)
+
+## Findings and Actions
+
+### Fixed: Mutable input-map tampering risk
+- Severity: Medium (integrity)
+- Risk: External caller could mutate input/tag/signal maps after object creation and change behavior implicitly.
+- Action: Added defensive copy + unmodifiable map in:
+  - `InputEvent.attributes`
+  - `Context.tags`
+  - `Candidate.signals`
+  - `FeatureVector.values`
+  - `PersistedModel.weights`
+- Verification: `testRecordInputMapsAreDefensivelyCopied`
+
+### Fixed: Feedback-to-trace mismatch poisoning risk
+- Severity: Medium (integrity)
+- Risk: `Updater.apply` accepted feedback for a different candidate than selected trace candidate.
+- Action: Added strict candidate id match validation.
+- Verification: `testUpdaterRejectsMismatchedFeedbackCandidate`
+
+## Residual Risk
+
+### Open: Replay protection is process-local only
+- Severity: Medium
+- Detail: `feedbackId` deduplication is in-memory; restart clears history, allowing replay.
+- Recommendation: persist applied feedback ledger with TTL and bounded storage.
+
+## Current Gate Status
+- local checks: `lint/unit/consistency/contract/compatibility/policy/security` all green.
+

--- a/src/main/java/com/geo/sdk/core/CoreSdk.java
+++ b/src/main/java/com/geo/sdk/core/CoreSdk.java
@@ -25,23 +25,35 @@ public final class CoreSdk {
             double longitude,
             long timestampEpochMs,
             Map<String, String> attributes) {
+        public InputEvent {
+            attributes = attributes == null ? Map.of() : Collections.unmodifiableMap(new HashMap<>(attributes));
+        }
     }
 
     public record Context(
             long nowEpochMs,
             String zoneId,
             Map<String, String> tags) {
+        public Context {
+            tags = tags == null ? Map.of() : Collections.unmodifiableMap(new HashMap<>(tags));
+        }
     }
 
     public record Candidate(
             String candidateId,
             String type,
             Map<String, Double> signals) {
+        public Candidate {
+            signals = signals == null ? Map.of() : Collections.unmodifiableMap(new HashMap<>(signals));
+        }
     }
 
     public record FeatureVector(
             String featureSchemaVersion,
             Map<String, Double> values) {
+        public FeatureVector {
+            values = values == null ? Map.of() : Collections.unmodifiableMap(new HashMap<>(values));
+        }
     }
 
     public record ScoreResult(
@@ -475,11 +487,20 @@ public final class CoreSdk {
             if (feedback.feedbackId() == null || feedback.feedbackId().isBlank()) {
                 throw new IllegalArgumentException("feedback.feedbackId must not be blank");
             }
+            if (feedback.candidateId() == null || feedback.candidateId().isBlank()) {
+                throw new IllegalArgumentException("feedback.candidateId must not be blank");
+            }
 
             // Idempotency: repeated apply for same feedbackId does nothing.
             String traceChecksum = checkpointChecksum(model, trace);
             if (appliedFeedback.containsKey(feedback.feedbackId())) {
                 return model;
+            }
+            if (trace.selectedCandidate() == null || trace.selectedCandidate().candidateId() == null) {
+                throw new IllegalArgumentException("trace.selectedCandidate must exist");
+            }
+            if (!feedback.candidateId().equals(trace.selectedCandidate().candidateId())) {
+                throw new IllegalArgumentException("feedback candidate mismatch");
             }
 
             history.push(model);
@@ -555,6 +576,9 @@ public final class CoreSdk {
             String featureSchemaVersion,
             Map<String, Double> weights,
             long revision) {
+        public PersistedModel {
+            weights = weights == null ? Map.of() : Collections.unmodifiableMap(new HashMap<>(weights));
+        }
     }
 
     public static final class CompatibilityLoader {

--- a/src/test/java/com/geo/sdk/core/SdkTestMain.java
+++ b/src/test/java/com/geo/sdk/core/SdkTestMain.java
@@ -40,8 +40,10 @@ public final class SdkTestMain {
         testPipelineSelectsBestCandidate();
         testPipelineSkipsWhenNoScorableCandidate();
         testPipelineContinuesAfterCandidateFailure();
+        testRecordInputMapsAreDefensivelyCopied();
         testUpdaterUndoAndDeterminism();
         testUpdaterIdempotencyAndCheckpointing();
+        testUpdaterRejectsMismatchedFeedbackCandidate();
     }
 
     private static void runCompatibility() {
@@ -261,6 +263,36 @@ public final class SdkTestMain {
         assertEquals(once.revision(), checkpoint.revisionAfter(), "checkpoint revision after");
     }
 
+    private static void testUpdaterRejectsMismatchedFeedbackCandidate() {
+        PipelineEngine engine = CoreSdk.defaultEngine();
+        ModelState base = CoreSdk.defaultModel();
+        InMemoryUpdater updater = new InMemoryUpdater(0.01, 4);
+
+        InputEvent input = new InputEvent("evt-up3", 35.0, 139.0, 1000L, Map.of("dwell_minutes", "7"));
+        Context ctx = new Context(8_000L, "Asia/Tokyo", Map.of());
+        Budget budget = new Budget(10, 0, 5, 1000L, 0L);
+        PipelineOutcome outcome = engine.run(input, ctx, budget, base);
+
+        FeedbackEvent feedback = new FeedbackEvent("fb-bad", "another-candidate", true, 9_000L);
+        assertThrows(() -> updater.apply(feedback, outcome.trace(), base), "feedback candidate mismatch");
+    }
+
+    private static void testRecordInputMapsAreDefensivelyCopied() {
+        Map<String, String> attrs = new HashMap<>();
+        attrs.put("dwell_minutes", "20");
+        InputEvent input = new InputEvent("evt-immutable", 0.0, 0.0, 1L, attrs);
+        attrs.put("dwell_minutes", "999");
+        assertEquals("20", input.attributes().get("dwell_minutes"), "input attributes should be immutable snapshot");
+        assertThrows(() -> input.attributes().put("new_key", "x"), "UnsupportedOperationException");
+
+        Map<String, Double> signals = new HashMap<>();
+        signals.put("presence", 1.0);
+        Candidate candidate = new Candidate("c-immutable", "location", signals);
+        signals.put("presence", 9.0);
+        assertEquals(1.0, candidate.signals().get("presence"), "candidate signals should be immutable snapshot");
+        assertThrows(() -> candidate.signals().put("x", 1.0), "UnsupportedOperationException");
+    }
+
     private static void testCompatibilityLoad() {
         CompatibilityLoader loader = new CompatibilityLoader();
         PersistedModel old = new PersistedModel("1", "1", Map.of("presence", 0.2, "stay", 0.4), 3);
@@ -334,7 +366,9 @@ public final class SdkTestMain {
             runnable.run();
             throw new AssertionError("Expected exception containing: " + expectedMessagePart);
         } catch (RuntimeException ex) {
-            if (ex.getMessage() == null || !ex.getMessage().contains(expectedMessagePart)) {
+            String message = ex.getMessage() == null ? "" : ex.getMessage();
+            String className = ex.getClass().getSimpleName();
+            if (!message.contains(expectedMessagePart) && !className.contains(expectedMessagePart)) {
                 throw new AssertionError("Unexpected exception message: " + ex.getMessage());
             }
         }


### PR DESCRIPTION
## Summary
- Hardened core SDK data integrity for security-sensitive paths:
  - defensive copy + immutability on record maps
  - strict `feedback.candidateId` vs `trace.selectedCandidate` match in updater
- Added security regression tests for both controls.
- Added security review report documenting fixed findings and residual risk.
- Opened follow-up issue for residual replay risk across restarts.

## Linked Issue
- Related #9
- Related #19

## Acceptance Criteria
- [x] mutable-map tampering risk mitigated
- [x] mismatched-feedback update poisoning blocked
- [x] findings and residual risk documented

## Test Evidence
- `ci/run-lint.sh`
- `ci/run-unit.sh`
- `ci/run-consistency.sh`
- `ci/run-contract.sh`
- `ci/run-compatibility.sh`
- `ci/run-policy.sh`
- `ci/run-security-audit.sh`

## Rollback Plan
- Revert this PR to restore previous update-path behavior.

## Security & Privacy Impact
- [x] Integrity hardening improved
- [x] No new external transfer path
- [x] No sensitive logging introduced
