### PR TITLE
fix: persist replay ledger across updater restarts

### DIFF
--- a/src/main/java/com/geo/sdk/core/CoreSdk.java
+++ b/src/main/java/com/geo/sdk/core/CoreSdk.java
@@ -1,8 +1,15 @@
 package com.geo.sdk.core;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Clock;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
@@ -460,22 +467,141 @@ public final class CoreSdk {
                 String checksumAfter) {
         }
 
+        public record ReplayRecord(
+                String feedbackId,
+                String checksum,
+                long appliedAtEpochMs) {
+        }
+
+        public interface ReplayLedger {
+            Map<String, ReplayRecord> load();
+
+            void save(Map<String, ReplayRecord> records);
+        }
+
+        public interface TimeSource {
+            long nowEpochMs();
+        }
+
+        public static final class SystemTimeSource implements TimeSource {
+            @Override
+            public long nowEpochMs() {
+                return Clock.systemUTC().millis();
+            }
+        }
+
+        public static final class NoopReplayLedger implements ReplayLedger {
+            @Override
+            public Map<String, ReplayRecord> load() {
+                return Map.of();
+            }
+
+            @Override
+            public void save(Map<String, ReplayRecord> records) {
+                // no-op
+            }
+        }
+
+        public static final class FileReplayLedger implements ReplayLedger {
+            private final Path path;
+
+            public FileReplayLedger(Path path) {
+                this.path = Objects.requireNonNull(path);
+            }
+
+            @Override
+            public Map<String, ReplayRecord> load() {
+                if (!Files.exists(path)) {
+                    return Map.of();
+                }
+                Map<String, ReplayRecord> result = new HashMap<>();
+                try {
+                    for (String line : Files.readAllLines(path, StandardCharsets.UTF_8)) {
+                        if (line.isBlank() || line.startsWith("#")) {
+                            continue;
+                        }
+                        String[] parts = line.split("\t", 3);
+                        if (parts.length != 3) {
+                            continue;
+                        }
+                        try {
+                            long epoch = Long.parseLong(parts[2]);
+                            ReplayRecord record = new ReplayRecord(parts[0], parts[1], epoch);
+                            result.put(parts[0], record);
+                        } catch (NumberFormatException ignore) {
+                            // skip malformed line
+                        }
+                    }
+                } catch (IOException ex) {
+                    throw new IllegalStateException("failed to load replay ledger: " + path, ex);
+                }
+                return result;
+            }
+
+            @Override
+            public void save(Map<String, ReplayRecord> records) {
+                try {
+                    Path parent = path.getParent();
+                    if (parent != null) {
+                        Files.createDirectories(parent);
+                    }
+                    List<ReplayRecord> sorted = records.values().stream()
+                            .sorted(Comparator.comparingLong(ReplayRecord::appliedAtEpochMs))
+                            .toList();
+                    List<String> lines = new ArrayList<>(sorted.size());
+                    for (ReplayRecord record : sorted) {
+                        lines.add(record.feedbackId() + "\t" + record.checksum() + "\t" + record.appliedAtEpochMs());
+                    }
+                    Files.write(path, lines, StandardCharsets.UTF_8,
+                            StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+                } catch (IOException ex) {
+                    throw new IllegalStateException("failed to save replay ledger: " + path, ex);
+                }
+            }
+        }
+
         private final double learningRate;
         private final int maxHistory;
+        private final long replayTtlMs;
+        private final int maxReplayEntries;
+        private final TimeSource timeSource;
+        private final ReplayLedger replayLedger;
         private final Deque<ModelState> history = new ArrayDeque<>();
         private final Deque<UpdateCheckpoint> checkpoints = new ArrayDeque<>();
-        private final Map<String, String> appliedFeedback = new HashMap<>();
+        private final Map<String, ReplayRecord> replayRecords = new HashMap<>();
 
         public InMemoryUpdater(double learningRate) {
             this(learningRate, 128);
         }
 
         public InMemoryUpdater(double learningRate, int maxHistory) {
+            this(learningRate, maxHistory, 14L * 24 * 60 * 60 * 1000, 64_000,
+                    new SystemTimeSource(), new NoopReplayLedger());
+        }
+
+        public InMemoryUpdater(
+                double learningRate,
+                int maxHistory,
+                long replayTtlMs,
+                int maxReplayEntries,
+                TimeSource timeSource,
+                ReplayLedger replayLedger) {
             this.learningRate = learningRate;
             if (maxHistory <= 0) {
                 throw new IllegalArgumentException("maxHistory must be > 0");
             }
+            if (replayTtlMs <= 0) {
+                throw new IllegalArgumentException("replayTtlMs must be > 0");
+            }
+            if (maxReplayEntries <= 0) {
+                throw new IllegalArgumentException("maxReplayEntries must be > 0");
+            }
             this.maxHistory = maxHistory;
+            this.replayTtlMs = replayTtlMs;
+            this.maxReplayEntries = maxReplayEntries;
+            this.timeSource = Objects.requireNonNull(timeSource);
+            this.replayLedger = Objects.requireNonNull(replayLedger);
+            initializeReplayLedger();
         }
 
         @Override
@@ -491,9 +617,12 @@ public final class CoreSdk {
                 throw new IllegalArgumentException("feedback.candidateId must not be blank");
             }
 
+            long now = timeSource.nowEpochMs();
+            pruneReplayLedger(now);
+
             // Idempotency: repeated apply for same feedbackId does nothing.
             String traceChecksum = checkpointChecksum(model, trace);
-            if (appliedFeedback.containsKey(feedback.feedbackId())) {
+            if (replayRecords.containsKey(feedback.feedbackId())) {
                 return model;
             }
             if (trace.selectedCandidate() == null || trace.selectedCandidate().candidateId() == null) {
@@ -525,8 +654,10 @@ public final class CoreSdk {
                     checkpointChecksum(model, trace),
                     checkpointChecksum(updated, trace));
             checkpoints.push(checkpoint);
-            appliedFeedback.put(feedback.feedbackId(), traceChecksum);
+            replayRecords.put(feedback.feedbackId(), new ReplayRecord(feedback.feedbackId(), traceChecksum, now));
             trimToMaxHistory();
+            trimReplayLedgerToLimit();
+            persistReplayLedger();
             return updated;
         }
 
@@ -538,7 +669,8 @@ public final class CoreSdk {
             ModelState previous = history.pop();
             if (!checkpoints.isEmpty()) {
                 UpdateCheckpoint checkpoint = checkpoints.pop();
-                appliedFeedback.remove(checkpoint.feedbackId());
+                replayRecords.remove(checkpoint.feedbackId());
+                persistReplayLedger();
             }
             return previous;
         }
@@ -552,9 +684,53 @@ public final class CoreSdk {
                 history.removeLast();
             }
             while (checkpoints.size() > maxHistory) {
-                UpdateCheckpoint dropped = checkpoints.removeLast();
-                appliedFeedback.remove(dropped.feedbackId());
+                checkpoints.removeLast();
             }
+        }
+
+        private void initializeReplayLedger() {
+            Map<String, ReplayRecord> loaded = replayLedger.load();
+            if (loaded == null || loaded.isEmpty()) {
+                return;
+            }
+            for (ReplayRecord record : loaded.values()) {
+                if (record == null || record.feedbackId() == null || record.feedbackId().isBlank()) {
+                    continue;
+                }
+                replayRecords.put(record.feedbackId(), record);
+            }
+            pruneReplayLedger(timeSource.nowEpochMs());
+            trimReplayLedgerToLimit();
+            persistReplayLedger();
+        }
+
+        private void pruneReplayLedger(long nowEpochMs) {
+            List<String> expired = new ArrayList<>();
+            for (ReplayRecord record : replayRecords.values()) {
+                if (nowEpochMs - record.appliedAtEpochMs() > replayTtlMs) {
+                    expired.add(record.feedbackId());
+                }
+            }
+            for (String feedbackId : expired) {
+                replayRecords.remove(feedbackId);
+            }
+        }
+
+        private void trimReplayLedgerToLimit() {
+            if (replayRecords.size() <= maxReplayEntries) {
+                return;
+            }
+            List<ReplayRecord> sorted = replayRecords.values().stream()
+                    .sorted(Comparator.comparingLong(ReplayRecord::appliedAtEpochMs))
+                    .toList();
+            int removeCount = replayRecords.size() - maxReplayEntries;
+            for (int i = 0; i < removeCount; i++) {
+                replayRecords.remove(sorted.get(i).feedbackId());
+            }
+        }
+
+        private void persistReplayLedger() {
+            replayLedger.save(replayRecords);
         }
 
         private static String checkpointChecksum(ModelState state, ExecutionTrace trace) {

--- a/src/test/java/com/geo/sdk/core/SdkTestMain.java
+++ b/src/test/java/com/geo/sdk/core/SdkTestMain.java
@@ -1,5 +1,8 @@
 package com.geo.sdk.core;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +47,9 @@ public final class SdkTestMain {
         testUpdaterUndoAndDeterminism();
         testUpdaterIdempotencyAndCheckpointing();
         testUpdaterRejectsMismatchedFeedbackCandidate();
+        testUpdaterReplayLedgerPersistsAcrossInstances();
+        testUpdaterReplayLedgerTtlExpiry();
+        testUpdaterReplayLedgerBounded();
     }
 
     private static void runCompatibility() {
@@ -293,6 +299,92 @@ public final class SdkTestMain {
         assertThrows(() -> candidate.signals().put("x", 1.0), "UnsupportedOperationException");
     }
 
+    private static void testUpdaterReplayLedgerPersistsAcrossInstances() {
+        try {
+            Path ledgerPath = Files.createTempFile("sdk-replay-ledger", ".tsv");
+            MutableTimeSource time = new MutableTimeSource(10_000L);
+            InMemoryUpdater.ReplayLedger ledger = new InMemoryUpdater.FileReplayLedger(ledgerPath);
+
+            PipelineEngine engine = CoreSdk.defaultEngine();
+            ModelState base = CoreSdk.defaultModel();
+            PipelineOutcome outcome = engine.run(
+                    new InputEvent("evt-ledger-1", 0.0, 0.0, 1L, Map.of("dwell_minutes", "6")),
+                    new Context(10_000L, "UTC", Map.of()),
+                    new Budget(10, 0, 10, 0L, 0L),
+                    base);
+
+            InMemoryUpdater updater1 = new InMemoryUpdater(0.01, 4, 86_400_000L, 100, time, ledger);
+            FeedbackEvent feedback = new FeedbackEvent("fb-ledger", outcome.trace().selectedCandidate().candidateId(), true, 10_100L);
+            ModelState once = updater1.apply(feedback, outcome.trace(), base);
+
+            InMemoryUpdater updater2 = new InMemoryUpdater(0.01, 4, 86_400_000L, 100, time, ledger);
+            ModelState twice = updater2.apply(feedback, outcome.trace(), once);
+
+            assertEquals(once.revision(), twice.revision(), "persisted replay ledger should block duplicate apply across instances");
+            Files.deleteIfExists(ledgerPath);
+        } catch (IOException ex) {
+            throw new AssertionError("unexpected io error: " + ex.getMessage());
+        }
+    }
+
+    private static void testUpdaterReplayLedgerTtlExpiry() {
+        try {
+            Path ledgerPath = Files.createTempFile("sdk-replay-ledger-ttl", ".tsv");
+            MutableTimeSource time = new MutableTimeSource(1_000L);
+            InMemoryUpdater.ReplayLedger ledger = new InMemoryUpdater.FileReplayLedger(ledgerPath);
+
+            PipelineEngine engine = CoreSdk.defaultEngine();
+            ModelState base = CoreSdk.defaultModel();
+            PipelineOutcome outcome = engine.run(
+                    new InputEvent("evt-ledger-ttl", 0.0, 0.0, 1L, Map.of("dwell_minutes", "6")),
+                    new Context(1_000L, "UTC", Map.of()),
+                    new Budget(10, 0, 10, 0L, 0L),
+                    base);
+
+            FeedbackEvent feedback = new FeedbackEvent("fb-ttl", outcome.trace().selectedCandidate().candidateId(), true, 1_100L);
+            InMemoryUpdater updater1 = new InMemoryUpdater(0.01, 4, 500L, 100, time, ledger);
+            updater1.apply(feedback, outcome.trace(), base);
+
+            time.set(2_000L);
+            InMemoryUpdater updater2 = new InMemoryUpdater(0.01, 4, 500L, 100, time, ledger);
+            ModelState reapplied = updater2.apply(feedback, outcome.trace(), base);
+            assertTrue(reapplied.revision() > base.revision(), "expired replay ledger entry should allow re-apply");
+            Files.deleteIfExists(ledgerPath);
+        } catch (IOException ex) {
+            throw new AssertionError("unexpected io error: " + ex.getMessage());
+        }
+    }
+
+    private static void testUpdaterReplayLedgerBounded() {
+        try {
+            Path ledgerPath = Files.createTempFile("sdk-replay-ledger-cap", ".tsv");
+            MutableTimeSource time = new MutableTimeSource(5_000L);
+            InMemoryUpdater.ReplayLedger ledger = new InMemoryUpdater.FileReplayLedger(ledgerPath);
+
+            PipelineEngine engine = CoreSdk.defaultEngine();
+            ModelState base = CoreSdk.defaultModel();
+            PipelineOutcome outcome = engine.run(
+                    new InputEvent("evt-ledger-cap", 0.0, 0.0, 1L, Map.of("dwell_minutes", "6")),
+                    new Context(5_000L, "UTC", Map.of()),
+                    new Budget(10, 0, 10, 0L, 0L),
+                    base);
+
+            InMemoryUpdater updater1 = new InMemoryUpdater(0.01, 8, 86_400_000L, 2, time, ledger);
+            ModelState m1 = updater1.apply(new FeedbackEvent("fb-cap-1", outcome.trace().selectedCandidate().candidateId(), true, 5_100L), outcome.trace(), base);
+            time.set(5_010L);
+            ModelState m2 = updater1.apply(new FeedbackEvent("fb-cap-2", outcome.trace().selectedCandidate().candidateId(), true, 5_110L), outcome.trace(), m1);
+            time.set(5_020L);
+            ModelState m3 = updater1.apply(new FeedbackEvent("fb-cap-3", outcome.trace().selectedCandidate().candidateId(), true, 5_120L), outcome.trace(), m2);
+
+            InMemoryUpdater updater2 = new InMemoryUpdater(0.01, 8, 86_400_000L, 2, time, ledger);
+            ModelState replayOld = updater2.apply(new FeedbackEvent("fb-cap-1", outcome.trace().selectedCandidate().candidateId(), true, 5_130L), outcome.trace(), m3);
+            assertTrue(replayOld.revision() > m3.revision(), "oldest feedback should be evicted when maxReplayEntries is exceeded");
+            Files.deleteIfExists(ledgerPath);
+        } catch (IOException ex) {
+            throw new AssertionError("unexpected io error: " + ex.getMessage());
+        }
+    }
+
     private static void testCompatibilityLoad() {
         CompatibilityLoader loader = new CompatibilityLoader();
         PersistedModel old = new PersistedModel("1", "1", Map.of("presence", 0.2, "stay", 0.4), 3);
@@ -371,6 +463,23 @@ public final class SdkTestMain {
             if (!message.contains(expectedMessagePart) && !className.contains(expectedMessagePart)) {
                 throw new AssertionError("Unexpected exception message: " + ex.getMessage());
             }
+        }
+    }
+
+    private static final class MutableTimeSource implements InMemoryUpdater.TimeSource {
+        private long now;
+
+        private MutableTimeSource(long now) {
+            this.now = now;
+        }
+
+        @Override
+        public long nowEpochMs() {
+            return now;
+        }
+
+        private void set(long now) {
+            this.now = now;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Implemented persisted replay ledger for `InMemoryUpdater` to prevent feedback replay across process restarts.
- Added TTL-based expiry and bounded-size trimming for replay records.
- Added pluggable replay ledger interfaces:
  - `NoopReplayLedger`
  - `FileReplayLedger`
- Added pluggable time source for deterministic replay tests.

## Linked Issue
- Closes #19

## Acceptance Criteria
- [x] replay dedup survives updater re-instantiation
- [x] replay records expire by TTL
- [x] replay ledger is bounded and evicts oldest entries
- [x] regression tests cover the above

## Test Evidence
- `ci/run-lint.sh`
- `ci/run-unit.sh`
- `ci/run-consistency.sh`
- `ci/run-contract.sh`
- `ci/run-compatibility.sh`
- `ci/run-policy.sh`
- `ci/run-security-audit.sh`

## Rollback Plan
- Revert this PR to restore in-memory-only replay behavior.

## Security & Privacy Impact
- [x] Improves model update integrity against replay across restarts
- [x] No new external transfer path
- [x] No sensitive logging introduced
