### PR TITLE
chore: prepare M2 formal release automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [v0.1.0] - 2026-03-05
+
+### Added
+- Multi-agent governance assets (PM/Orchestrator/Test/Security runbooks)
+- Core SDK pipeline with pluggable contracts and candidate-evaluation trace
+- Policy controls, compatibility loader reporting, and updater replay-ledger persistence
+- Formal release automation script (`scripts/release.sh`)
+
+### Changed
+- CI split into contract/consistency/compatibility/policy/security lanes
+- Security audit hardening for no-transfer and log minimization enforcement
+- Release operation standardized with rehearsal and formal runbooks
+
+### Notes
+- First formal public release from `main`.
+
 ## [v0.1.0-rc1] - 2026-03-05 (rehearsal)
 
 ### Added

--- a/docs/agents/acceptance-board.md
+++ b/docs/agents/acceptance-board.md
@@ -1,9 +1,9 @@
 # Acceptance Board
 
 ## Milestone Status
-- Current milestone: M1
-- State: done
-- Last updated: 2026-03-05 (release-tag rehearsal completed)
+- Current milestone: M2
+- State: in-progress
+- Last updated: 2026-03-05 (M2 formal release started)
 
 ## Gate Checklist
 
@@ -19,6 +19,12 @@
 - [x] #6 updater apply/undo + checkpoints
 - [x] #7 compatibility loader hardening
 - [x] release-tag rehearsal (`v0.1.0-rc1` temporary tag flow validated and cleaned up)
+
+### M2
+- [x] formal release automation prepared (`scripts/release.sh`, runbook)
+- [ ] `v0.1.0` tag created on origin
+- [ ] GitHub Release published (`isDraft=false`, `isPrerelease=false`)
+- [ ] release URL recorded
 
 ## Blockers
 - none

--- a/docs/agents/release-runbook.md
+++ b/docs/agents/release-runbook.md
@@ -1,0 +1,36 @@
+# Formal Release Runbook
+
+## Purpose
+M2で正式リリース (`vX.Y.Z`) を公開し、タグ・Release・CHANGELOG・受け入れ状態を一致させる。
+
+## Target (current)
+- Version: `v0.1.0`
+- Repository: `shgnaka/geo-event-trigger-core-sdk`
+
+## Preconditions
+- Current branch is `main`
+- Working tree is clean
+- GitHub CLI authenticated
+- Required checks all green:
+  - `lint`
+  - `unit`
+  - `consistency`
+  - `contract`
+  - `compatibility`
+  - `policy`
+  - `security`
+
+## Command
+```bash
+scripts/release.sh v0.1.0 shgnaka/geo-event-trigger-core-sdk
+```
+
+## Expected Output
+- Annotated tag `v0.1.0` exists on origin
+- GitHub Release for `v0.1.0` is published (`isDraft=false`, `isPrerelease=false`)
+- Release URL is recorded in acceptance board
+
+## Post Steps
+1. Update `docs/agents/acceptance-board.md` M2 checklist
+2. Ensure `CHANGELOG.md` has finalized `v0.1.0` notes
+3. Confirm open issues/PRs relevant to release are triaged

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:-v0.1.0}"
+REPO="${2:-shgnaka/geo-event-trigger-core-sdk}"
+TITLE="${3:-$VERSION}"
+NOTES_FILE="${NOTES_FILE:-}"
+
+require_clean_main() {
+  local branch
+  branch="$(git rev-parse --abbrev-ref HEAD)"
+  if [ "$branch" != "main" ]; then
+    echo "Must run on main branch. current=$branch"
+    exit 1
+  fi
+  if [ -n "$(git status --porcelain)" ]; then
+    echo "Working tree must be clean."
+    exit 1
+  fi
+}
+
+run_checks() {
+  ci/run-lint.sh
+  ci/run-unit.sh
+  ci/run-consistency.sh
+  ci/run-contract.sh
+  ci/run-compatibility.sh
+  ci/run-policy.sh
+  ci/run-security-audit.sh
+}
+
+tag_exists_remote() {
+  git ls-remote --tags origin "refs/tags/$VERSION" | grep -q "$VERSION"
+}
+
+create_release() {
+  if [ -n "$NOTES_FILE" ]; then
+    gh release create "$VERSION" \
+      --repo "$REPO" \
+      --target main \
+      --title "$TITLE" \
+      --notes-file "$NOTES_FILE"
+  else
+    gh release create "$VERSION" \
+      --repo "$REPO" \
+      --target main \
+      --title "$TITLE" \
+      --generate-notes
+  fi
+}
+
+main() {
+  require_clean_main
+
+  if git rev-parse "$VERSION" >/dev/null 2>&1; then
+    echo "Tag already exists locally: $VERSION"
+    exit 1
+  fi
+  if tag_exists_remote; then
+    echo "Tag already exists on origin: $VERSION"
+    exit 1
+  fi
+
+  echo "[1/5] running release checks"
+  run_checks
+
+  echo "[2/5] creating annotated tag $VERSION"
+  git tag -a "$VERSION" -m "release $VERSION"
+
+  echo "[3/5] pushing tag to origin"
+  git push origin "$VERSION"
+
+  echo "[4/5] creating GitHub release"
+  create_release
+
+  echo "[5/5] release completed: $VERSION"
+  gh release view "$VERSION" --repo "$REPO" --json tagName,isDraft,isPrerelease,url
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Added `scripts/release.sh` for formal release execution (`vX.Y.Z`) without cleanup.
- Added formal release runbook (`docs/agents/release-runbook.md`).
- Updated acceptance board to start M2 formal-release checklist.
- Added finalized `v0.1.0` section in changelog.

## Linked Issue
- Related #25

## Acceptance Criteria
- [x] formal release script exists and is syntax-validated
- [x] formal release runbook exists
- [x] M2 checklist is defined in acceptance board
- [x] changelog has formal release section

## Test Evidence
- `bash -n scripts/release.sh`
- `ci/run-lint.sh`
- `ci/run-unit.sh`
- `ci/run-consistency.sh`
- `ci/run-contract.sh`
- `ci/run-compatibility.sh`
- `ci/run-policy.sh`
- `ci/run-security-audit.sh`

## Rollback Plan
- Revert this PR to return to previous release operation state.
