### PR TITLE
chore: finalize M2 release acceptance board

### DIFF
--- a/docs/agents/acceptance-board.md
+++ b/docs/agents/acceptance-board.md
@@ -2,8 +2,8 @@
 
 ## Milestone Status
 - Current milestone: M2
-- State: in-progress
-- Last updated: 2026-03-05 (M2 formal release started)
+- State: done
+- Last updated: 2026-03-05 (v0.1.0 formal release published)
 
 ## Gate Checklist
 
@@ -22,9 +22,9 @@
 
 ### M2
 - [x] formal release automation prepared (`scripts/release.sh`, runbook)
-- [ ] `v0.1.0` tag created on origin
-- [ ] GitHub Release published (`isDraft=false`, `isPrerelease=false`)
-- [ ] release URL recorded
+- [x] `v0.1.0` tag created on origin
+- [x] GitHub Release published (`isDraft=false`, `isPrerelease=false`)
+- [x] release URL recorded: `https://github.com/shgnaka/geo-event-trigger-core-sdk/releases/tag/v0.1.0`
 
 ## Blockers
 - none


### PR DESCRIPTION
## Summary
- Updated acceptance board to reflect completed M2 formal release.
- Recorded published v0.1.0 release URL.
- Marked all M2 checklist items complete.

## Linked Issue
- Closes #25

## Acceptance Criteria
- [x] M2 state is `done`
- [x] v0.1.0 release evidence is recorded
- [x] checklist fully complete

## Test Evidence
- docs-only update; release was executed via `scripts/release.sh` on main.
