### PR TITLE
chore: finalize core SDK spec and add spec-mvp template

### DIFF
--- a/docs/agents/acceptance-board.md
+++ b/docs/agents/acceptance-board.md
@@ -3,7 +3,7 @@
 ## Milestone Status
 - Current milestone: M2
 - State: done
-- Last updated: 2026-03-05 (v0.1.0 formal release published)
+- Last updated: 2026-03-05 (v0.1.0 formal release and spec finalization completed)
 
 ## Gate Checklist
 
@@ -25,6 +25,7 @@
 - [x] `v0.1.0` tag created on origin
 - [x] GitHub Release published (`isDraft=false`, `isPrerelease=false`)
 - [x] release URL recorded: `https://github.com/shgnaka/geo-event-trigger-core-sdk/releases/tag/v0.1.0`
+- [x] core SDK spec finalized (`docs/geo-event-trigger-core-sdk-spec.md: status=stable`)
 
 ## Blockers
 - none

--- a/docs/agents/spec-implementation-matrix.md
+++ b/docs/agents/spec-implementation-matrix.md
@@ -1,0 +1,23 @@
+# Spec-Implementation Matrix
+
+## Core SDK Spec Alignment
+
+| Spec Item | Status | Evidence |
+|---|---|---|
+| 6 core contracts fixed | Implemented | `CoreSdk.requiredContracts()`, `SdkTestMain.testContractSignaturesPublished` |
+| Pipeline multi-candidate evaluation and best selection | Implemented | `PipelineEngine.run`, `testPipelineSelectsBestCandidate` |
+| Candidate-level failure isolation | Implemented | `PipelineEngine.run`, `testPipelineContinuesAfterCandidateFailure` |
+| Policy boundary controls (threshold/daily/question/cooldown) | Implemented | `BudgetPolicyEngine`, `testPolicyBoundaries` |
+| Policy forced controls and invalid input fail-safe | Implemented | `BudgetPolicyEngine`, `testPolicyForceAndValidationControls` |
+| Updater apply/undo and reproducibility checkpoints | Implemented | `InMemoryUpdater`, `testUpdaterUndoAndDeterminism` |
+| Replay dedup persistence across restarts | Implemented | `FileReplayLedger`, `testUpdaterReplayLedgerPersistsAcrossInstances` |
+| Compatibility loading + migration report | Implemented | `CompatibilityLoader.loadWithReport`, `testCompatibilityLoad` |
+| Downgrade rejection and unsupported version failure | Implemented | `CompatibilityLoader`, `testCompatibilityRejectsUnsupportedOrDowngrade` |
+| No external transfer / log minimization runtime gate | Implemented | `ci/run-security-audit.sh`, `docs/agents/security-audit-controls.md` |
+| Formal release operation (`v0.1.0`) | Implemented | `scripts/release.sh`, release `v0.1.0` |
+| Android wrapper implementation | Deferred | out-of-scope for core SDK repo |
+
+## Deferred Items
+- Android wrapper/app integration.
+- Domain-specific UI flow and copy.
+

--- a/docs/geo-event-trigger-core-sdk-spec.md
+++ b/docs/geo-event-trigger-core-sdk-spec.md
@@ -2,7 +2,7 @@
 title: "コンテキスト介入中核SDK仕様"
 date: "2026-03-05"
 tags: ["context-aware", "sdk", "on-device-learning", "location", "policy-engine"]
-status: "refine"
+status: "stable"
 updated: "2026-03-05"
 hypothesis: "Detector/Policy/Actionを分離したSDK化により、用途別ラッパーを短期間で展開できる。"
 impact: 5
@@ -14,12 +14,14 @@ risk: 3
 
 位置・滞在・通知・学習ロジックをアプリごとに個別実装すると、機能追加のたびに再実装が発生し、検証と保守のコストが高い。
 
-## Idea
+## Architecture
 
-端末内完結の中核SDKを定義し、アプリ側は用途別ラッパーとして `Detector / Policy / Action` の設定とUIだけを担当する。  
-中核は `InputEvent -> Candidate -> Feature -> Score -> ActionPlan -> Feedback -> Update` の共通パイプラインとして提供する。
+中核SDKは `InputEvent -> Candidate -> Feature -> Score -> ActionPlan -> Feedback -> Update` を共通パイプラインとして提供する。  
+アプリ側ラッパーは `Detector / Policy / Action` の設定とUI責務を持つ。
 
-主要インターフェースは次を固定する。
+## Core Contracts
+
+固定インターフェース:
 
 - `Detector.detect(input, ctx) -> Candidate[]`
 - `FeatureExtractor.extract(candidate, ctx) -> FeatureVector`
@@ -28,39 +30,74 @@ risk: 3
 - `Updater.apply(feedback, trace, model) -> ModelState`
 - `ActionExecutor.execute(plan) -> ActionResult`
 
+補助契約:
+
+- `Updater.undo() -> ModelState`（直前更新の復元）
+- `CompatibilityLoader.load(persisted, targetModelVersion, targetFeatureSchemaVersion) -> ModelState`
+- `CompatibilityLoader.loadWithReport(...) -> CompatibilityLoadResult`
+
+## Behavior Guarantees
+
+### Pipeline
+
+- 候補が複数ある場合は評価可能候補を走査し、最高スコア候補を採用する。
+- 候補単位の例外は全体停止させず、候補評価結果に失敗理由を残す。
+- 評価可能候補がない場合は `SKIP(no-scorable-candidate)` を返す。
+
+### Policy
+
+- `askThreshold`, 日次上限、質問予算、クールダウンを評価する。
+- 失敗安全側として `invalid-budget` / `invalid-score` は `SKIP`。
+- コンテキスト強制制御 (`policy_force_silent`, `policy_force_skip`) を許可する。
+
+### Updater
+
+- `feedbackId` で重複適用を抑止する。
+- `feedback.candidateId` と `trace.selectedCandidate` が不一致なら更新を拒否する。
+- Replay ledger は永続化可能で、TTLと件数上限で管理する。
+- `undo()` は直前状態へロールバックし、関連チェックポイントも巻き戻す。
+
+### Compatibility
+
+- `feature_schema_version` / `model_version` の互換読み込みを提供する。
+- downgrade は不許可。
+- 移行内容は `appliedMigrations` / `warnings` で取得可能。
+
+## Security & Privacy Constraints
+
+- 位置データ・学習データはデフォルトで端末外送信しない。
+- Core runtime に外部送信プリミティブと endpoint literal を置かない。
+- 生位置/生コンテキスト等の機微データをログ出力しない。
+
+## Validation Criteria
+
+1. 契約テスト
+- すべてのプラグイン実装が共通I/O契約を満たす。
+- 成功判定: `Detector/Policy/Action` 差し替え後も同一テスト群が通る。
+
+2. 学習整合性テスト
+- `FeedbackEvent` の重み更新、`Undo` 復元、再実行決定再現性を検証。
+- 成功判定: 直前更新を完全復元し、重複適用を抑止できる。
+
+3. 互換性テスト
+- `feature_schema_version` と `model_version` の互換読み込みを検証。
+- 成功判定: 旧版データから現行版へ移行し、未対応/不正versionは明示失敗。
+
+4. ポリシー挙動テスト
+- クールダウン、日次上限、質問予算、強制制御を検証。
+- 成功判定: 予算超過時に `Ask` を抑制し、理由コードが一致する。
+
 ## Assumptions
 
 - 初期ターゲットはAndroid中心で、オフライン優先とする。
-- 位置データや学習データはデフォルトで端末外に送信しない。
 - SDKはUIを持たず、ラッパー側で画面遷移・文言を実装する。
-- 特徴量スキーマとモデルはバージョン管理し、将来の差分更新に対応する。
-
-## Validation Plan
-
-1. 契約テスト
-- すべてのプラグイン実装が共通I/O契約を満たすことを確認する。
-- 成功判定: `Detector/Policy/Action` 差し替え後も同じテスト群が通る。
-
-2. 学習整合性テスト
-- `FeedbackEvent` に対する重み更新と `Undo` ロールバックを検証する。
-- 成功判定: 直前更新の完全復元と、再実行時の決定再現性を満たす。
-
-3. 互換性テスト
-- `feature_schema_version` と `model_version` の互換読み込みを検証する。
-- 成功判定: 旧版データから現行版モデルへ移行できる。
-
-4. ポリシー挙動テスト
-- クールダウン、日次上限、質問予算を跨ぐ境界ケースを検証する。
-- 成功判定: 予算超過時に `Ask` が抑制される。
+- 特徴量スキーマとモデルはバージョン管理し、差分更新に対応する。
 
 ## Decision Log
 
-- 2026-03-05: `refine` に作成。理由: 位置文脈アプリ群で再利用可能な中核仕様を先に固定するため。
-- 2026-03-05: 提供形態は `組み込みSDK` を採用。
-- 2026-03-05: 抽象単位は `Detector + Policy + Action` の3プラグインを採用。
-- 2026-03-05: 端末内完結（位置データ外部送信なし）をデフォルト方針として採用。
+- 2026-03-05: `refine` として作成。
+- 2026-03-05: 提供形態は `組み込みSDK`。
+- 2026-03-05: 抽象単位は `Detector + Policy + Action`。
+- 2026-03-05: 端末内完結（外部送信なし）をデフォルト方針。
 - 2026-03-05: ラッパー責務を「UI・ドメイン設定・フィードバック取得」に限定。
-
-## Next Action
-
-実装リポジトリ向けに、上記インターフェースを `templates/spec-mvp.md` 形式でAPI契約として転記する。
+- 2026-03-05: 実装整合を反映し `stable` に昇格。

--- a/templates/spec-mvp.md
+++ b/templates/spec-mvp.md
@@ -1,0 +1,47 @@
+# Spec MVP Template
+
+## Metadata
+- Title:
+- Status: (`draft` | `refine` | `stable`)
+- Updated:
+- Owner:
+
+## Goal
+- What problem this spec solves.
+
+## Core Pipeline
+- `Input -> Candidate -> Feature -> Score -> Decision -> Feedback -> Update`
+
+## Public Contracts
+- `Detector.detect(input, ctx) -> Candidate[]`
+- `FeatureExtractor.extract(candidate, ctx) -> FeatureVector`
+- `Scorer.score(features, model) -> ScoreResult`
+- `Policy.decide(score, budget, ctx) -> ActionPlan`
+- `Updater.apply(feedback, trace, model) -> ModelState`
+- `ActionExecutor.execute(plan) -> ActionResult`
+
+## Behavioral Guarantees
+- Selection strategy:
+- Failure handling:
+- Idempotency / replay behavior:
+- Version compatibility behavior:
+
+## Security & Privacy Constraints
+- External transfer policy:
+- Sensitive logging policy:
+- Data retention policy:
+
+## Validation Plan
+- Contract tests:
+- Consistency tests:
+- Compatibility tests:
+- Policy tests:
+- Security tests:
+
+## Implementation Mapping
+- Implemented:
+- Partial:
+- Deferred:
+
+## Change Log
+- YYYY-MM-DD:


### PR DESCRIPTION
## Summary
- Updated core SDK spec from `refine` to `stable` with implementation-aligned behavior guarantees.
- Added reusable `templates/spec-mvp.md` for future spec work.
- Added spec-implementation alignment matrix for quick status review.
- Updated acceptance board with spec-finalization completion.

## Linked Issue
- Closes #28

## Acceptance Criteria
- [x] spec status promoted to `stable`
- [x] spec-mvp template added
- [x] implementation alignment matrix added
- [x] acceptance board updated

## Test Evidence
- `ci/run-lint.sh`
- `ci/run-contract.sh`
- `ci/run-consistency.sh`

## Rollback Plan
- Revert this PR to restore previous spec documentation state.
