### PR TITLE
docs: add CI incident runbook for outage/quota triage

### DIFF
--- a/docs/agents/ci-incident-runbook.md
+++ b/docs/agents/ci-incident-runbook.md
@@ -1,0 +1,43 @@
+# CI Incident Runbook
+
+Issue: #31 (`agent:orchestrator`), #1 (`agent:pm`)
+
+## Purpose
+GitHub Actions check failure時に、コード不具合とCI基盤障害を迅速に切り分ける。
+
+## Triage Steps
+1. 対象PRのcheck一覧を確認:
+   - `gh pr checks <PR_NUMBER>`
+2. 失敗ジョブのログを確認:
+   - `gh run view <RUN_ID> --job <JOB_ID> --log-failed`
+3. 失敗種別を分類:
+   - `Service Unavailable` / `Failed to resolve action download info`: 基盤側一時障害
+   - `minutes` / `billing` / `spending limit exceeded`: 利用枠超過
+   - テスト失敗/アサーション失敗: コード不具合
+
+## Recovery Actions
+### A. 基盤側一時障害
+1. 失敗ジョブのみ再実行:
+   - `gh run rerun <RUN_ID> --failed`
+2. 15分以内に同一エラー継続時:
+   - PRを `status:blocked` にして次サイクルへ繰越
+   - Orchestrator decision logへ記録
+
+### B. 利用枠超過
+1. 利用枠を確認（`user` scope 必要）:
+   - `gh auth refresh -h github.com -s user`
+   - `gh api /users/<USER>/settings/billing/actions`
+2. PMが当日対応を決定:
+   - 追加枠確保 or 実行頻度の一時抑制
+3. 対応完了まで新規PRのマージを保留
+
+### C. コード不具合
+1. 失敗テストの担当agentへアサイン
+2. 修正PRで再検証
+
+## Evidence Required
+- PRコメントに以下を残す:
+  - 発生日時（UTC）
+  - 失敗ジョブURL
+  - 判定カテゴリ（A/B/C）
+  - 実施アクションと結果

--- a/docs/agents/orchestrator-runbook.md
+++ b/docs/agents/orchestrator-runbook.md
@@ -51,6 +51,7 @@ Issue: #2 (`agent:orchestrator`)
 ## Artifacts
 - 決定ログ: `docs/agents/orchestrator-decision-log.md`
 - 週次サマリ: `docs/agents/orchestrator-weekly-template.md`
+- CI障害対応: `docs/agents/ci-incident-runbook.md`
 
 ## Integration Lane Extension
 - Lane I1 (Distribution): artifact baseline and version coordinates.

--- a/docs/agents/pm-cadence.md
+++ b/docs/agents/pm-cadence.md
@@ -26,6 +26,7 @@ Issue: #1 (`agent:pm`)
 - If blocker exceeds SLA:
   - escalate to PM decision log
   - freeze dependent lane until owner and ETA are explicit
+- CI障害判定は `docs/agents/ci-incident-runbook.md` に従う
 
 ## Acceptance Gates
 ### M0 Gate


### PR DESCRIPTION
## Summary
- add CI incident runbook for outage vs quota triage
- link runbook from orchestrator and PM cadence docs

## Validation
- ci/run-lint.sh
- ci/run-unit.sh
- ci/run-consistency.sh
- ci/run-contract.sh
- ci/run-compatibility.sh
- ci/run-policy.sh
- ci/run-security-audit.sh

Closes #36
