### PR TITLE
docs: organize release notes for integrator-facing clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,29 @@
 # Changelog
 
 All notable changes to this project are documented in this file.
+The format follows Keep a Changelog style with project-specific integration notes.
 
 ## [Unreleased]
+### Added
+- None.
+
+### Changed
+- None.
+
+### Fixed
+- None.
+
+### Security
+- None.
+
+### Integration Notes
+- None.
+
+### Breaking Changes
+- None.
+
+### Upgrade Notes
+- None.
 
 ## [v0.1.0] - 2026-03-05
 
@@ -11,11 +32,41 @@ All notable changes to this project are documented in this file.
 - Core SDK pipeline with pluggable contracts and candidate-evaluation trace
 - Policy controls, compatibility loader reporting, and updater replay-ledger persistence
 - Formal release automation script (`scripts/release.sh`)
+- App integration lane assets:
+  - artifact build script (`scripts/build_artifact.sh`)
+  - consumer verification script (`scripts/verify_consumer.sh`)
+  - quick start guide (`docs/quick-start.md`)
+  - minimal wrapper sample (`examples/minimal-wrapper/...`)
 
 ### Changed
 - CI split into contract/consistency/compatibility/policy/security lanes
 - Security audit hardening for no-transfer and log minimization enforcement
 - Release operation standardized with rehearsal and formal runbooks
+- CI incident triage runbook added for outage vs quota diagnosis (`docs/agents/ci-incident-runbook.md`)
+
+### Fixed
+- None.
+
+### Security
+- Security gate explicitly validates integration assets for:
+  - no network transfer defaults
+  - no sensitive payload logging examples
+
+### Integration Notes
+- First stable integration baseline for external apps is now available:
+  - group: `com.geo.sdk`
+  - artifact: `geo-event-trigger-core-sdk`
+  - version: `0.1.0`
+- Recommended onboarding entrypoint:
+  1. Build artifact (`scripts/build_artifact.sh 0.1.0`)
+  2. Follow quick-start (`docs/quick-start.md`)
+  3. Validate consumer (`scripts/verify_consumer.sh 0.1.0`)
+
+### Breaking Changes
+- None.
+
+### Upgrade Notes
+- First stable release. No migration required.
 
 ### Notes
 - First formal public release from `main`.
@@ -31,6 +82,9 @@ All notable changes to this project are documented in this file.
 ### Changed
 - CI split into contract/consistency/compatibility/policy/security lanes
 - Release rehearsal automation script and runbook introduced
+
+### Breaking Changes
+- None.
 
 ### Notes
 - `v0.1.0-rc1` is rehearsal-only and intentionally not retained as a remote tag.

--- a/docs/agents/release-notes-style-guide.md
+++ b/docs/agents/release-notes-style-guide.md
@@ -1,0 +1,29 @@
+# Release Notes Style Guide
+
+## Goal
+Provide release notes that help integrators decide whether to upgrade, how to upgrade, and what to verify.
+
+## Required Sections
+For each stable release entry in `CHANGELOG.md`, include:
+- `Added`
+- `Changed`
+- `Fixed`
+- `Security`
+- `Integration Notes`
+- `Breaking Changes`
+- `Upgrade Notes`
+
+If a section has no updates, write `None.` explicitly.
+
+## Writing Rules
+- Write for app integrators, not only SDK maintainers.
+- Prefer impact statements over implementation detail.
+- Include concrete version coordinates when relevant.
+- Include links/paths to onboarding docs or scripts for validation.
+- Keep security-related changes separate from generic fixes.
+
+## Minimum Quality Checklist
+- Integrator can tell whether migration is needed.
+- Integrator can identify what to run for validation.
+- Security-relevant changes are visible without reading code diffs.
+- Release entry matches GitHub Release title/tag/date.

--- a/docs/agents/release-runbook.md
+++ b/docs/agents/release-runbook.md
@@ -33,4 +33,5 @@ scripts/release.sh v0.1.0 shgnaka/geo-event-trigger-core-sdk
 ## Post Steps
 1. Update `docs/agents/acceptance-board.md` M2 checklist
 2. Ensure `CHANGELOG.md` has finalized `v0.1.0` notes
-3. Confirm open issues/PRs relevant to release are triaged
+3. Validate release note format with `docs/agents/release-notes-style-guide.md`
+4. Confirm open issues/PRs relevant to release are triaged


### PR DESCRIPTION
## Summary
- restructure changelog entries for integrator-facing release notes readability
- add release notes style guide with required sections and checklist
- reference style guide from formal release runbook post steps

## Validation
- ci/run-lint.sh
- ci/run-consistency.sh
- ci/run-policy.sh

Closes #38
